### PR TITLE
Print env info to stdout rather than to stderr

### DIFF
--- a/bench/db_bench.cc
+++ b/bench/db_bench.cc
@@ -397,7 +397,7 @@ private:
     void PrintEnvironment() {
 #if defined(__linux)
         time_t now = time(NULL);
-        fprintf(stderr, "Date:       %s", ctime(&now));  // ctime() adds newline
+        fprintf(stdout, "Date:       %s", ctime(&now));  // ctime() adds newline
 
         FILE *cpuinfo = fopen("/proc/cpuinfo", "r");
         if (cpuinfo != NULL) {
@@ -420,8 +420,8 @@ private:
                 }
             }
             fclose(cpuinfo);
-            fprintf(stderr, "CPU:        %d * %s\n", num_cpus, cpu_type.c_str());
-            fprintf(stderr, "CPUCache:   %s\n", cache_size.c_str());
+            fprintf(stdout, "CPU:        %d * %s\n", num_cpus, cpu_type.c_str());
+            fprintf(stdout, "CPUCache:   %s\n", cache_size.c_str());
         }
 #endif
     }


### PR DESCRIPTION
it's useful to save this info in logs from execution.

todo mark: perhaps in future it should be extended with more info.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv-tools/25)
<!-- Reviewable:end -->
