### PR TITLE
Update default list for the benchmarks

### DIFF
--- a/bench/db_bench.cc
+++ b/bench/db_bench.cc
@@ -57,7 +57,7 @@ static const std::string USAGE =
 
 // Default list of comma-separated operations to run
 static const char *FLAGS_benchmarks =
-        "fillrandom,overwrite,fillseq,readrandom,readseq,readrandom,readmissing,readrandom,deleteseq";
+        "fillseq,fillrandom,overwrite,readseq,readrandom,readmissing,deleteseq,deleterandom,readwhilewriting,readrandomwriterandom";
 
 // Default engine name
 static const char *FLAGS_engine = "cmap";


### PR DESCRIPTION
The default list doesn't cover every benchmark option. 
The user who runs with the default command will not test all of them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv-tools/30)
<!-- Reviewable:end -->
