### PR TITLE
Fix redundant code for the GenerateKeyFromInt function

### DIFF
--- a/bench/db_bench.cc
+++ b/bench/db_bench.cc
@@ -574,7 +574,7 @@ public:
 	{
 		char *start = const_cast<char *>(key->data());
 		char *pos = start;
-		int bytes_to_fill = std::min(key_size_ - static_cast<int>(pos - start), 8);
+		int bytes_to_fill = std::min(key_size_, 8);
 		if (missing) {
 			int64_t v1 = -v;
 			memcpy(pos, static_cast<void *>(&v1), bytes_to_fill);


### PR DESCRIPTION
There is a redundant code in the function for GenerateKeyFromInt. The variable 'pos' and 'start' are always equal, so the expression of (pos - start) is always 0. I think this expression should be deleted. Thanks for you review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv-bench/48)
<!-- Reviewable:end -->
