### PR TITLE
Remove txfillrandom from list of default parameters

### DIFF
--- a/bench/db_bench.cc
+++ b/bench/db_bench.cc
@@ -1021,7 +1021,7 @@ int main(int argc, char **argv)
 {
 	// Default list of comma-separated operations to run
 	static const char *FLAGS_benchmarks =
-		"fillseq,fillrandom,txfillrandom,overwrite,readseq,readrandom,readmissing,deleteseq,deleterandom,readwhilewriting,readrandomwriterandom";
+		"fillseq,fillrandom,overwrite,readseq,readrandom,readmissing,deleteseq,deleterandom,readwhilewriting,readrandomwriterandom";
 	// Default engine name
 	static const char *FLAGS_engine = "cmap";
 


### PR DESCRIPTION
Default engine for pmemkv_bench is cmap, which doesn't support
transactions

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv-bench/54)
<!-- Reviewable:end -->
