### PR TITLE
fix DoWrite for disjoint=1

### DIFF
--- a/bench/db_bench.cc
+++ b/bench/db_bench.cc
@@ -794,8 +794,8 @@ private:
 		Slice key = AllocateKey(key_guard);
 
 		auto num = FLAGS_disjoint ? num_ / FLAGS_threads : num_;
-		auto start = FLAGS_disjoint ? thread->tid * num_ : 0;
-		auto end = FLAGS_disjoint ? (thread->tid + 1) * num_ : num_;
+		auto start = FLAGS_disjoint ? thread->tid * num : 0;
+		auto end = FLAGS_disjoint ? (thread->tid + 1) * num : num_;
 
 		pmem::kv::status s;
 		int64_t bytes = 0;


### PR DESCRIPTION
start and end should be calculated using per thread number of elements

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv-bench/57)
<!-- Reviewable:end -->
