### PR TITLE
CI: allow usage of different workdir/project_dir in docker's entrypoint

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,8 @@
 on: [push, pull_request]
 
+env:
+  WORKDIR:   ${{ github.workspace }}
+
 jobs:
   pmemkv-bench-CI:
     runs-on: ubuntu-latest

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,7 +8,7 @@ set -x
 
 echo "$1"
 
-project_dir=/pmemkv-bench
+project_dir=${WORKDIR:-/pmemkv-bench}
 
 echo "run basic test"
 pytest-3 -v ${project_dir}/tests/test.py


### PR DESCRIPTION
Important for various docker images, which may use the same entrypoint.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv-bench/63)
<!-- Reviewable:end -->
