### PR TITLE
Various fixes (part 2)

### DIFF
--- a/.github/action.yml
+++ b/.github/action.yml
@@ -8,6 +8,6 @@ runs:
   using: 'docker'
   image: '../Dockerfile'
   env:
-    TEST_PATH: '/tmp/pmemkv-bench'
+    KV_BENCH_TEST_PATH: '/tmp/pmemkv-bench'
   args:
     - ${{ inputs.entrypoint_params }}

--- a/Makefile
+++ b/Makefile
@@ -7,21 +7,24 @@ bench: CFLAGS = $(shell pkg-config --cflags libpmemkv libpmempool) -DOS_LINUX -f
 bench: LDFLAGS = -ldl -lpthread $(shell pkg-config --libs libpmemkv libpmempool)
 CPP_FILES = $(shell find . -iname "*.h" -o -iname "*.cc" -o -iname "*.cpp" -o -iname "*.hpp")
 PYTHON_FILES = $(shell find . -iname "*.py")
+KV_BENCH_TEST_PATH ?= /dev/shm/pmemkv
 
 
 .PHONY: cppformat $(CPP_FILES) pythonformat $(PYTHON_FILES)
 
 bench: reset
-	g++ ./bench/db_bench.cc ./bench/port/port_posix.cc ./bench/util/env.cc ./bench/util/env_posix.cc ./bench/util/histogram.cc ./bench/util/logging.cc ./bench/util/status.cc ./bench/util/testutil.cc -o pmemkv_bench -I./bench/include -I./bench -I./bench/util $(CFLAGS) $(LDFLAGS)
+	g++ ./bench/db_bench.cc ./bench/port/port_posix.cc ./bench/util/env.cc ./bench/util/env_posix.cc \
+		./bench/util/histogram.cc ./bench/util/logging.cc ./bench/util/status.cc ./bench/util/testutil.cc \
+		-o pmemkv_bench -I./bench/include -I./bench -I./bench/util $(CFLAGS) $(LDFLAGS)
 
 reset:
-	rm -rf /dev/shm/pmemkv /tmp/pmemkv
+	rm -rf $(KV_BENCH_TEST_PATH)
 
 clean: reset
 	rm -rf pmemkv_bench
 
 run_bench: bench
-	PMEM_IS_PMEM_FORCE=1 ./pmemkv_bench --db=/dev/shm/pmemkv --db_size_in_gb=1 --histogram=1
+	PMEM_IS_PMEM_FORCE=1 ./pmemkv_bench --db=$(KV_BENCH_TEST_PATH) --db_size_in_gb=1 --histogram=1
 
 cppformat: $(CPP_FILES)
 

--- a/README.md
+++ b/README.md
@@ -76,10 +76,10 @@ To simply run `pmemkv-bench` on DRAM:
 PMEM_IS_PMEM_FORCE=1 ./pmemkv_bench --db=/dev/shm/pmemkv --db_size_in_gb=1
 ```
 
-or using make command:
+or using make command (with custom testing path):
 
 ```sh
-make run_bench
+make run_bench [ KV_BENCH_TEST_PATH=<test_path> ]
 ```
 
 **Alternatively** you can run building selected version of pmemkv
@@ -90,8 +90,7 @@ using python script (available in project's root directory):
 python3 run_benchmark.py <build_config_file> <bench_scenarios_file>
 ```
 
-Example usage of this script is also shown in
-[one of our tests](./tests/test.py#L49).
+Example usage of this script is also shown in [one of our tests](./tests/test.py).
 
 ### Various Pools
 

--- a/bench/db_bench.cc
+++ b/bench/db_bench.cc
@@ -600,7 +600,11 @@ public:
 		return Slice(key_guard.get(), key_size_);
 	}
 
-	void GenerateKeyFromInt(uint64_t v, int64_t num_keys, Slice *key, bool missing = false)
+	/**
+	 * Create key with binary value of v and filled up with '0',
+	 * up to key_size (if needed).
+	 */
+	void GenerateKeyFromInt(uint64_t v, Slice *key, bool missing = false)
 	{
 		char *start = const_cast<char *>(key->data());
 		char *pos = start;
@@ -827,7 +831,7 @@ private:
 
 			for (int i = n; i < n + batch_size; i++) {
 				const int k = seq ? i : (thread->rand.Next() % num) + start;
-				GenerateKeyFromInt(k, FLAGS_num, &key);
+				GenerateKeyFromInt(k, &key);
 				std::string value = std::string();
 				value.append(value_size_, 'X');
 				s = inserter.put(key.ToString(), value);
@@ -871,7 +875,7 @@ private:
 
 		for (int i = start; i < end; i++) {
 			const int k = seq ? i : (thread->rand.Next() % num) + start;
-			GenerateKeyFromInt(k, FLAGS_num, &key, missing);
+			GenerateKeyFromInt(k, &key, missing);
 			std::string value;
 			if (kv_->get(key.ToString(), &value) == pmem::kv::status::OK)
 				found++;
@@ -905,7 +909,7 @@ private:
 		Slice key = AllocateKey(key_guard);
 		for (int i = 0; i < num_; i++) {
 			const int k = seq ? i : (thread->rand.Next() % FLAGS_num);
-			GenerateKeyFromInt(k, FLAGS_num, &key);
+			GenerateKeyFromInt(k, &key);
 			kv_->remove(key.ToString());
 			thread->stats.FinishedSingleOp();
 		}
@@ -945,7 +949,7 @@ private:
 				}
 			}
 
-			GenerateKeyFromInt(thread->rand.Next() % FLAGS_num, FLAGS_num, &key);
+			GenerateKeyFromInt(thread->rand.Next() % FLAGS_num, &key);
 			pmem::kv::status s;
 
 			if (write_merge == kWrite) {
@@ -988,7 +992,7 @@ private:
 
 		/* the number of iterations is the larger of read_ or write_ */
 		while (!duration.Done(1)) {
-			GenerateKeyFromInt(thread->rand.Next() % FLAGS_num, FLAGS_num, &key);
+			GenerateKeyFromInt(thread->rand.Next() % FLAGS_num, &key);
 			if (get_weight == 0 && put_weight == 0) {
 				/* one batch completed, reinitialize for next batch */
 				get_weight = FLAGS_readwritepercent;

--- a/bench/db_bench.cc
+++ b/bench/db_bench.cc
@@ -414,7 +414,7 @@ struct ThreadState {
 	Stats stats;
 	SharedState *shared;
 
-	ThreadState(int index) : tid(index), rand(1000 + index)
+	ThreadState(int index) : tid(index), rand(time(NULL))
 	{
 	}
 };

--- a/bench/db_bench.cc
+++ b/bench/db_bench.cc
@@ -7,7 +7,7 @@
 // (found in the LICENSE file in the root directory).
 
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2017-2021, Intel Corporation
+/* Copyright 2017-2021, Intel Corporation */
 
 #include <chrono>
 #include <cstdio>
@@ -71,29 +71,29 @@ static const std::string USAGE =
 	"    readrandomwriterandom  (N threads doing random-read, random-write)\n"
 	"    txfillrandom           (load N values in random key order transactionally)\n";
 
-// Number of key/values to place in database
+/* Number of key/values to place in database */
 static int FLAGS_num = 1000000;
 
 static bool FLAGS_disjoint = false;
 
-// Number of read operations to do.  If negative, do FLAGS_num reads.
+/* Number of read operations to do. If negative, do FLAGS_num reads. */
 static int FLAGS_reads = -1;
 
-// Number of concurrent threads to run.
+/* Number of concurrent threads to run. */
 static int FLAGS_threads = 1;
 
 static int FLAGS_key_size = 8;
 
-// Size of each value
+/* Size of each value */
 static int FLAGS_value_size = 100;
 
-// Print histogram of operation timings
+/* Print histogram of operation timings */
 static bool FLAGS_histogram = false;
 
-// Use the db with the following name.
+/* Use the db with the following name. */
 static const char *FLAGS_db = "/dev/shm/pmemkv";
 
-// Use following size when opening the database.
+/* Use following size when opening the database. */
 static int FLAGS_db_size_in_gb = 0;
 
 static const double FLAGS_compression_ratio = 1.0;
@@ -127,7 +127,7 @@ static Slice TrimSpace(Slice s)
 
 #endif
 
-// Helper for quickly generating random data.
+/* Helper for quickly generating random data. */
 class RandomGenerator {
 private:
 	std::string data_;
@@ -136,14 +136,14 @@ private:
 public:
 	RandomGenerator()
 	{
-		// We use a limited amount of data over and over again and ensure
-		// that it is larger than the compression window (32KB), and also
-		// large enough to serve all typical value sizes we want to write.
+		/* We use a limited amount of data over and over again and ensure
+		 * that it is larger than the compression window (32KB), and also
+		 * large enough to serve all typical value sizes we want to write. */
 		Random rnd(301);
 		std::string piece;
 		while (data_.size() < (unsigned)std::max(1048576, FLAGS_value_size)) {
-			// Add a short fragment that is as compressible as specified
-			// by FLAGS_compression_ratio.
+			/* Add a short fragment that is as compressible as specified
+			 * by FLAGS_compression_ratio. */
 			test::CompressibleString(&rnd, FLAGS_compression_ratio, 100, &piece);
 			data_.append(piece);
 		}
@@ -276,7 +276,7 @@ public:
 		start_ = g_env->NowMicros();
 		finish_ = start_;
 		message_.clear();
-		// When set, stats from this thread won't be merged with others.
+		/* When set, stats from this thread won't be merged with others */
 		exclude_from_merge_ = false;
 	}
 
@@ -294,7 +294,7 @@ public:
 		if (other.finish_ > finish_)
 			finish_ = other.finish_;
 
-		// Just keep the messages from one thread
+		/* Just keep the messages from one thread */
 		if (message_.empty())
 			message_ = other.message_;
 	}
@@ -348,8 +348,8 @@ public:
 
 	float get_micros_per_op()
 	{
-		// Pretend at least one op was done in case we are running a benchmark
-		// that does not call FinishedSingleOp().
+		/* Pretend at least one op was done in case we are running a benchmark
+		 * that does not call FinishedSingleOp(). */
 		if (done_ < 1)
 			done_ = 1;
 		return seconds_ * 1e6 / done_;
@@ -357,8 +357,8 @@ public:
 
 	float get_ops_per_sec()
 	{
-		// Pretend at least one op was done in case we are running a benchmark
-		// that does not call FinishedSingleOp().
+		/* Pretend at least one op was done in case we are running a benchmark
+		 * that does not call FinishedSingleOp(). */
 		if (done_ < 1)
 			done_ = 1;
 		double elapsed = (finish_ - start_) * 1e-6;
@@ -368,8 +368,8 @@ public:
 
 	float get_throughput()
 	{
-		// Rate and ops/sec is computed on actual elapsed time, not the sum of per-thread
-		// elapsed times.
+		/* Rate and ops/sec is computed on actual elapsed time, not the sum of per-thread
+		 * elapsed times. */
 		double elapsed = (finish_ - start_) * 1e-6;
 		return (bytes_ / 1048576.0) / elapsed;
 	}
@@ -385,17 +385,18 @@ public:
 	}
 };
 
-// State shared by all concurrent executions of the same benchmark.
+/* State shared by all concurrent executions of the same benchmark. */
 struct SharedState {
 	port::Mutex mu;
 	port::CondVar cv;
 	int total;
 
-	// Each thread goes through the following states:
-	//    (1) initializing
-	//    (2) waiting for others to be initialized
-	//    (3) running
-	//    (4) done
+	/* Each thread goes through the following states:
+	 * (1) initializing
+	 * (2) waiting for others to be initialized
+	 * (3) running
+	 * (4) done
+	 */
 
 	int num_initialized;
 	int num_done;
@@ -406,10 +407,10 @@ struct SharedState {
 	}
 };
 
-// Per-thread state for concurrent executions of the same benchmark.
+/* Per-thread state for concurrent executions of the same benchmark. */
 struct ThreadState {
-	int tid;     // 0..n-1 when running in n threads
-	Random rand; // Has different seeds for different threads
+	int tid;     /* 0..n-1 when running in n threads */
+	Random rand; /* Has different seeds for different threads */
 	Stats stats;
 	SharedState *shared;
 
@@ -439,11 +440,11 @@ public:
 	bool Done(int64_t increment)
 	{
 		if (increment <= 0)
-			increment = 1; // avoid Done(0) and infinite loops
+			increment = 1; /* avoid Done(0) and infinite loops */
 		ops_ += increment;
 
 		if (max_seconds_) {
-			// Recheck every appx 1000 ops (exact iff increment is factor of 1000)
+			/* Recheck every appx 1000 ops (exact iff increment is factor of 1000) */
 			auto granularity = FLAGS_ops_between_duration_checks;
 			if ((ops_ / granularity) != ((ops_ - increment) / granularity)) {
 				time_point now = std::chrono::high_resolution_clock::now();
@@ -922,11 +923,11 @@ private:
 
 	void BGWriter(ThreadState *thread, enum OperationType write_merge)
 	{
-		// Special thread that keeps writing until other threads are done.
+		/* Special thread that keeps writing until other threads are done. */
 		RandomGenerator gen;
 		int64_t bytes = 0;
 
-		// Don't merge stats from this thread with the readers.
+		/* Don't merge stats from this thread with the readers. */
 		thread->stats.SetExcludeFromMerge();
 
 		std::unique_ptr<const char[]> key_guard;
@@ -939,7 +940,7 @@ private:
 				MutexLock l(&thread->shared->mu);
 
 				if (thread->shared->num_done + 1 >= thread->shared->num_initialized) {
-					// Finish the write immediately
+					/* Finish the write immediately */
 					break;
 				}
 			}
@@ -985,11 +986,11 @@ private:
 		std::unique_ptr<const char[]> key_guard;
 		Slice key = AllocateKey(key_guard);
 
-		// the number of iterations is the larger of read_ or write_
+		/* the number of iterations is the larger of read_ or write_ */
 		while (!duration.Done(1)) {
 			GenerateKeyFromInt(thread->rand.Next() % FLAGS_num, FLAGS_num, &key);
 			if (get_weight == 0 && put_weight == 0) {
-				// one batch completed, reinitialize for next batch
+				/* one batch completed, reinitialize for next batch */
 				get_weight = FLAGS_readwritepercent;
 				put_weight = 100 - get_weight;
 			}
@@ -1008,8 +1009,8 @@ private:
 				reads_done++;
 				thread->stats.FinishedSingleOp();
 			} else if (put_weight > 0) {
-				// then do all the corresponding number of puts
-				// for all the gets we have done earlier
+				/* then do all the corresponding number of puts
+				 * for all the gets we have done earlier */
 				pmem::kv::status s =
 					kv_->put(key.ToString(), gen.Generate(value_size_).ToString());
 				if (s != pmem::kv::status::OK) {
@@ -1037,13 +1038,13 @@ private:
 
 int main(int argc, char **argv)
 {
-	// Default list of comma-separated operations to run
+	/* Default list of comma-separated operations to run */
 	static const char *FLAGS_benchmarks =
 		"fillseq,fillrandom,overwrite,readseq,readrandom,readmissing,deleteseq,deleterandom,readwhilewriting,readrandomwriterandom";
-	// Default engine name
+	/* Default engine name */
 	static const char *FLAGS_engine = "cmap";
 
-	// Print usage statement if necessary
+	/* Print usage statement if necessary */
 	if (argc != 1) {
 		if ((strcmp(argv[1], "?") == 0) || (strcmp(argv[1], "-?") == 0) ||
 		    (strcmp(argv[1], "h") == 0) || (strcmp(argv[1], "-h") == 0) ||
@@ -1052,7 +1053,8 @@ int main(int argc, char **argv)
 			exit(1);
 		}
 	}
-	// Parse command-line arguments
+
+	/* Parse command-line arguments */
 	for (int i = 1; i < argc; i++) {
 		int n;
 		char junk;
@@ -1088,7 +1090,7 @@ int main(int argc, char **argv)
 		}
 	}
 
-	// Run benchmark against default environment
+	/* Run benchmark against default environment */
 	g_env = leveldb::Env::Default();
 
 	BenchmarkLogger logger = BenchmarkLogger();

--- a/tests/test.py
+++ b/tests/test.py
@@ -32,16 +32,24 @@ def test_help():
 @pytest.mark.parametrize(
     "engine,test_path,benchmarks",
     [
-        ("cmap", os.getenv("TEST_PATH", "/dev/shm/pmemkv"), "fillrandom,readrandom"),
-        ("csmap", os.getenv("TEST_PATH", "/dev/shm/pmemkv"), "fillrandom,readrandom"),
+        (
+            "cmap",
+            os.getenv("KV_BENCH_TEST_PATH", "/dev/shm/pmemkv"),
+            "fillrandom,readrandom",
+        ),
+        (
+            "csmap",
+            os.getenv("KV_BENCH_TEST_PATH", "/dev/shm/pmemkv"),
+            "fillrandom,readrandom",
+        ),
         (
             "vcmap",
-            os.path.dirname(os.getenv("TEST_PATH", "/dev/shm/pmemkv")),
+            os.path.dirname(os.getenv("KV_BENCH_TEST_PATH", "/dev/shm/pmemkv")),
             "fillrandom,readrandom",
         ),
         (
             "vsmap",
-            os.path.dirname(os.getenv("TEST_PATH", "/dev/shm/pmemkv")),
+            os.path.dirname(os.getenv("KV_BENCH_TEST_PATH", "/dev/shm/pmemkv")),
             "fillrandom,readrandom",
         ),
     ],
@@ -107,7 +115,7 @@ def test_json(engine, test_path, benchmarks):
         {
             "env": {},
             "params": {
-                "--db": os.getenv("TEST_PATH", "/dev/shm/pmemkv"),
+                "--db": os.getenv("KV_BENCH_TEST_PATH", "/dev/shm/pmemkv"),
                 "--db_size_in_gb": "2",
                 "--benchmarks": "fillseq",
                 "--engine": "radix",


### PR DESCRIPTION
Update Makefile to use 'KV_BENCH_TEST_PATH' env var, not just clean some hardcoded paths - if our tests are run with custom test path they won't work, since we don't clean the testing path before the next test and kv.open() fails.

\+ few minor fixes, i.a.:
- fix error messages,
- update comments in bench.cc to C-style,
- get rid of dead code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv-bench/69)
<!-- Reviewable:end -->
