### PR TITLE
Fix makefile targets and code formatting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,13 +17,15 @@ If you want to format your cpp code you can make adequate target:
 make cppformat
 ```
 
-for python scripts (using python's black formatter), use:
+**NOTE**: We're using specific **clang-format** - version **11.0** is required.
+
+for python scripts use:
 
 ```sh
 make pyformat
 ```
 
-**NOTE**: We're using specific clang-format - version **11.0** is required.
+**NOTE**: We're using specific **black** formatter - version **21.4b2** is required.
 
 # Submitting Pull Requests
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN apt update && \
 	python3-pip \
  && rm -rf /var/lib/apt/lists/*
 
-RUN pip3 install black
+RUN pip3 install black==21.4b2
 
 COPY . /pmemkv-bench
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ PYTHON_FILES = $(shell find . -iname "*.py")
 KV_BENCH_TEST_PATH ?= /dev/shm/pmemkv
 
 
-.PHONY: cppformat $(CPP_FILES) pythonformat $(PYTHON_FILES)
+.PHONY: cppformat check-cppformat $(CPP_FILES) pyformat check-pyformat $(PYTHON_FILES)
 
 bench: reset
 	g++ ./bench/db_bench.cc ./bench/port/port_posix.cc ./bench/util/env.cc ./bench/util/env_posix.cc \
@@ -33,7 +33,7 @@ $(CPP_FILES):
 
 check-cppformat:
 	@for src in $(CPP_FILES) ; do \
-		clang-format-11 --verbose --Werror -n "$$src"
+		clang-format-11 --verbose --Werror -n "$$src" || exit 1 ;\
 	done
 
 pyformat: $(PYTHON_FILES)
@@ -43,5 +43,6 @@ $(PYTHON_FILES):
 
 check-pyformat:
 	@for src in $(PYTHON_FILES) ; do \
-		python3 -m black "$$src" --check
+		echo "$$src" ;\
+		python3 -m black "$$src" --check || exit 1 ;\
 	done

--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ Contributions are also welcome - take a look at our [CONTRIBUTING.md](CONTRIBUTI
 * [**python3**](https://www.python.org/download/releases/3.0/) - for executing additional python scripts (and tests)
 * Used only for **development**:
 	* [**clang-format-11**](https://clang.llvm.org/docs/ClangFormat.html) -
-        to format and check coding style, version 11 is required
+        to format and check cpp coding style, version 11 is required
+	* [**black 21.4b2**](https://github.com/psf/black) -
+        to format and check python coding style, version 21.4b2 is required
 
 See our **[Dockerfile](./Dockerfile)** (used e.g. on our CI system) to get an idea what packages
 are required to build and run pmemkv-bench.

--- a/bench/db_bench.cc
+++ b/bench/db_bench.cc
@@ -742,7 +742,8 @@ private:
 	}
 
 	/* Throw exception for failed put (with proper message) */
-	void throw_put_error(int i, leveldb::Slice key, pmem::kv::status s) {
+	void throw_put_error(int i, leveldb::Slice key, pmem::kv::status s)
+	{
 		std::string prnt_key = key.ToString();
 		std::ostringstream err_msg;
 		err_msg << "Put error for " << std::to_string(i) << "-th key: ";
@@ -756,8 +757,8 @@ private:
 			}
 		}
 
-		err_msg << " (pmemkv status: " << std::to_string(int(s))
-			<< ", error: '" << pmem::kv::errormsg() << "')";
+		err_msg << " (pmemkv status: " << std::to_string(int(s)) << ", error: '"
+			<< pmem::kv::errormsg() << "')";
 		throw std::runtime_error(err_msg.str());
 	}
 
@@ -844,8 +845,8 @@ private:
 			thread->stats.FinishedSingleOp();
 			if (s != pmem::kv::status::OK) {
 				throw std::runtime_error("Commit failed at batch " +
-							 std::to_string(n / batch_size) +
-							 "\nError '" + pmem::kv::errormsg() + "'");
+							 std::to_string(n / batch_size) + "\nError '" +
+							 pmem::kv::errormsg() + "'");
 			}
 		}
 		thread->stats.AddBytes(bytes);

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,4 +17,3 @@ make check-pyformat
 
 echo "run basic test"
 pytest-3 -v ./tests/test.py
-

--- a/tests/test.py
+++ b/tests/test.py
@@ -21,7 +21,7 @@ def create_config_file(configuration):
 
 
 def test_help():
-    """ Simple sanity check for -h option of run_benchmark.py. """
+    """Simple sanity check for -h option of run_benchmark.py."""
     sys.argv = ["dummy.py", "-h"]
     with pytest.raises(SystemExit) as e:
         result = rb.main()


### PR DESCRIPTION
Our makefile targets failed properly only if the last file was improper, not if e.g. first file was badly formatted.

By the way of this change I selected one version of black formatter, since I had different version on my machine and it wasn't compatible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv-bench/76)
<!-- Reviewable:end -->
