### PR TITLE
Fix units in README and help

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Nonetheless, the most important runtime parameters are:
 --engine=<name>            (storage engine name, default: cmap)
 --db=<location>            (path to persistent pool, default: /dev/shm/pmemkv_test_db)
                            (note: file on DAX filesystem, DAX device, or poolset file)
---db_size_in_gb=<integer>  (size of persistent pool to create in GB, default: 0)
+--db_size_in_gb=<integer>  (size of persistent pool to create in GiB, default: 0)
                            (note: for existing poolset or device DAX configs use 0 or leave default value)
                            (note: when pool path is non-existing, value should be > 0)
 --histogram=<0|1>          (show histograms when reporting latencies)

--- a/bench/db_bench.cc
+++ b/bench/db_bench.cc
@@ -37,7 +37,7 @@ static const std::string USAGE =
 	"--engine=<name>            (storage engine name, default: cmap)\n"
 	"--db=<location>            (path to persistent pool, default: /dev/shm/pmemkv_test_db)\n"
 	"                           (note: file on DAX filesystem, DAX device, or poolset file)\n"
-	"--db_size_in_gb=<integer>  (size of persistent pool to create in GB, default: 0)\n"
+	"--db_size_in_gb=<integer>  (size of persistent pool to create in GiB, default: 0)\n"
 	"                           (note: for existing poolset or device DAX configs use 0 or leave default value)\n"
 	"                           (note: when pool path is non-existing, value should be > 0)\n"
 	"--histogram=<0|1>          (show histograms when reporting latencies)\n"


### PR DESCRIPTION
Using predefined constants from std::ratio is more readable
than hardcoding multiplication.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv-bench/80)
<!-- Reviewable:end -->
